### PR TITLE
Fix width calculation for multi-character end tokens

### DIFF
--- a/src/comment-box.js
+++ b/src/comment-box.js
@@ -580,12 +580,14 @@ function convertToCommentBox(text, options) {
         .map(line => alignmentStyle(line, width - edgesWidth, fillingToken))
 
     const widthWithoutRightEdge = width - stringWidth(rightEdgeToken)
+    const widthWithoutTopRightEdge = width - stringWidth(topRightToken)
+    const widthWithoutEndToken = width - stringWidth(endToken)
     const skipFirstLine = topEdgeToken === ""
     const skipLastLine = bottomEdgeToken === ""
 
     const firstLine = skipFirstLine ?
         "" :
-        padRight(startToken, widthWithoutRightEdge, topEdgeToken) + topRightToken + "\n"
+        padRight(startToken, widthWithoutTopRightEdge, topEdgeToken) + topRightToken + "\n"
 
     const midLines = lines
         .map((str, line) => {
@@ -603,7 +605,7 @@ function convertToCommentBox(text, options) {
 
     const lastLine = skipLastLine ?
         "" :
-        padRight(bottomLeftToken, widthWithoutRightEdge, bottomEdgeToken) + endToken
+        padRight(bottomLeftToken, widthWithoutEndToken, bottomEdgeToken) + endToken
 
     const result = firstLine + midLines + lastLine
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -154,9 +154,7 @@ function addStyledComment(editor, { style, config }) {
             selectionText: text
         } = userSelection(editor, current, style, config.extendSelection)
 
-        // text = convertToCommentBox(text, style)
-        text = JSON.stringify(getStyleList(), null, 4)
-        text += '\n' + JSON.stringify(style, null, 4)
+        text = convertToCommentBox(text, style)
 
         return {
             text,


### PR DESCRIPTION
- Calculate widths separately for topRightToken, endToken, and rightEdgeToken
- Remove debug code that was outputting JSON instead of comment boxes

This addresses an issue where the end tokens go beyond the width of the comment box.

For example, if the start token is `/*` and end token is `*/` then without this fix, we get:
```
/*─────────────────────────────────────────────────────────────────────────────┐
│                                 GAMEPLAY TAGS                                │
└──────────────────────────────────────────────────────────────────────────────*/
```
With the fix, we get:
```
/*─────────────────────────────────────────────────────────────────────────────┐
│                                 GAMEPLAY TAGS                                │
└─────────────────────────────────────────────────────────────────────────────*/
```